### PR TITLE
Add home and end button support to input area.

### DIFF
--- a/inputarea.go
+++ b/inputarea.go
@@ -579,7 +579,11 @@ func (field *InputArea) MoveCursorEnd(moveFar, extendSelection bool) {
 	} else {
 		after := field.GetText()[field.GetCursorOffset():]
 		firstLineEndOffset := strings.Index(after, "\n")
-		diff = firstLineEndOffset
+		if firstLineEndOffset >= 0 {
+			diff = firstLineEndOffset
+		} else {
+			diff = len(after)
+		}
 	}
 	if extendSelection {
 		field.extendSelection(diff)


### PR DESCRIPTION
Hi :wave:

I found this TUI library after using gomuks. While using gomuks I missed being able to jump to the beginning/end of the line/text using the home and end button. So I tried to implement them for the `InputArea` :)

The current implementation is:

- KeyHome moves the cursor to the beginning of the line
- Ctrl + KeyHome moves the cursor to the beginning of the entire text
- Shift + (Ctr +) KeyHome extends the selection to the beginning of the line/text (optionally reducing the selection first, if the cursor is to the right of the selection)
- KeyEnd moves the cursor to the end of the line
- Ctrl + KeyEnd moves the cursor to the end of the entire text
- Shift + (Ctr +) KeyEnd extends the selection to the end of the line/text (optionally reducing the selection first, if the cursor is to the left of the selection)

I hope this fits in this project and makes its way into gomuks.
Kind regards,
yeldiR