### PR TITLE
Use tcell style.Reverse for highlight

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module go.mau.fi/mauview
 go 1.18
 
 require (
-	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mattn/go-runewidth v0.0.14
 	github.com/rivo/uniseg v0.4.2
 	github.com/zyedidia/clipboard v1.0.4
@@ -12,6 +11,7 @@ require (
 
 require (
 	github.com/gdamore/encoding v1.0.0 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	golang.org/x/sys v0.2.0 // indirect
 	golang.org/x/term v0.2.0 // indirect
 	golang.org/x/text v0.4.0 // indirect

--- a/textview.go
+++ b/textview.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"unicode/utf8"
 
-	"github.com/lucasb-eyer/go-colorful"
 	"github.com/mattn/go-runewidth"
 
 	"go.mau.fi/tcell"
@@ -898,18 +897,9 @@ func (t *TextView) Draw(screen Screen) {
 				}
 			}
 			if highlighted {
-				fg, bg, _ := style.Decompose()
-				if bg == tcell.ColorDefault {
-					r, g, b := fg.RGB()
-					c := colorful.Color{R: float64(r) / 255, G: float64(g) / 255, B: float64(b) / 255}
-					_, _, li := c.Hcl()
-					if li < .5 {
-						bg = tcell.ColorWhite
-					} else {
-						bg = tcell.ColorBlack
-					}
-				}
-				style = style.Background(fg).Foreground(bg)
+				_, _, attrs := style.Decompose()
+				reversed := attrs&tcell.AttrReverse != 0
+				style = style.Reverse(!reversed)
 			}
 
 			// Skip to the right.


### PR DESCRIPTION
Only tested in gomuks' fuzzy room switcher. I guess tcell's Reverse uses [SGR 7 ANSI escape](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters) so this should be a more robust way to deal with highlights.

Tested with gnome-terminal, st & urxvt