### PR TITLE
Add a custom mouse event wrapper around tcell's one

### DIFF
--- a/eventhandler.go
+++ b/eventhandler.go
@@ -38,6 +38,15 @@ type PasteEvent interface {
 	Text() string
 }
 
+type customMouseEvent struct {
+	*tcell.EventMouse
+	motion bool
+}
+
+func (cme customMouseEvent) HasMotion() bool {
+	return cme.motion
+}
+
 // MouseEvent is an interface of the *tcell.EventMouse type.
 type MouseEvent interface {
 	tcell.Event


### PR DESCRIPTION
This wrapper implements the HasMotion() function which value is set by the main application based on the previous mouse event.

If I understood https://github.com/gdamore/tcell/issues/622#issuecomment-1837580304 correctly (emphasis is mine):

> Just so we are clear here -- what discriminates a "click" vs. a held drag, is that a click will send an event with buttons set to none. **If you get multiple location reports with the buttons unchanged, then the user has been holding the buttons.**


With this change, we should be able to use upstream tcell. See #10 

I tested this quickly in Gomuks and the selection of text in the message input seemd to behave as expected.