### PR TITLE
No break in SetFocused loop applies old focus after exiting

### DIFF
--- a/flex.go
+++ b/flex.go
@@ -130,6 +130,7 @@ func (flex *Flex) SetFocused(comp Component) {
 		if child.target == comp {
 			flex.focused = &child
 			flex.focused.Focus()
+			break
 		}
 	}
 }

--- a/flex.go
+++ b/flex.go
@@ -126,9 +126,10 @@ func (flex *Flex) OnPasteEvent(event PasteEvent) bool {
 }
 
 func (flex *Flex) SetFocused(comp Component) {
-	for _, child := range flex.children {
-		if child.target == comp {
-			flex.focused = &child
+	for i := range flex.children {
+		childp := &flex.children[i]
+		if childp.target == comp {
+			flex.focused = childp
 			flex.focused.Focus()
 			break
 		}


### PR DESCRIPTION
In `gomuks`, ran into a tsrange problem with `SetFocused`. It is not updating `flex.focused` unless a `break` is added to the loope, despite the condition matching and updating only once.

Added debug logging,

```
func (flex *Flex) SetFocused(comp Component) {

	dbglog(fmt.Sprintf("SetFocused on component %p\n", comp))
	for _, child := range flex.children {
		if child.target == comp {
			dbglog(fmt.Sprintf("    found component match %p == %p\n", child.target, comp))
			flex.focused = &child
			flex.focused.Focus()
		}
	}
	dbglog(fmt.Sprintf("    flex focused target: %p\n", flex.focused.target))
}
```

The focused component is only matched and updated once, yet the focused target is still set to the older value.

```
SetFocused on component 0xc0000e41b0
    found component match 0xc0000e41b0 == 0xc0000e41b0
    flex focused target: 0xc000000140
```

Adding a break to the loop after a match is found fixes the issue.