### PR TITLE
Fix scroll regression introduced in #11

### DIFF
--- a/application.go
+++ b/application.go
@@ -134,7 +134,8 @@ func (app *Application) Start() error {
 					redraw = app.root.OnPasteEvent(customEvt)
 				}
 			case *tcell.EventMouse:
-				hasMotion := app.prevMouseEvt.Buttons() == event.Buttons()
+				onlyButtons := event.Buttons() < tcell.WheelUp
+				hasMotion := onlyButtons && app.prevMouseEvt.Buttons() == event.Buttons()
 				customEvt := customMouseEvent{event, hasMotion}
 				app.prevMouseEvt = event
 				redraw = app.root.OnMouseEvent(customEvt)


### PR DESCRIPTION
Simply checking that the Buttons bitset of both events is the same is not enough to set the motion to true. We have to make sure that the event is only for buttons and not for the mouseweel.

Fixes https://github.com/tulir/mauview/pull/11#issuecomment-2045068021
